### PR TITLE
Add GNOME 41 support to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
       "3.38",
       "40",
       "40.0",
-      "40.1"
+      "40.1",
+      "41"
    ],
    "url": "https://github.com/brendaw/add-username-toppanel",
    "version": 3


### PR DESCRIPTION
Tested on GNOME 41 on X11 on NixOS unstable, works perfectly