### PR TITLE
Updates to support GNOME Shell 45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is inspired on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres (in parts) to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0](https://github.com/brendaw/add-username-toppanel/releases/tag/v3.0) - 2023-11-06
+
+### Changed
+
+- Convert to ES6 with ESM required to support GNOME Shell version 45 (thanks, [@josholith](https://github.com/josholith))
+
+## [2.1](https://github.com/brendaw/add-username-toppanel/releases/tag/v2.1) - 2023-05-10
+
+### Added
+
+- Added support to GNOME Shell version 44 (thanks, [@cemozden ](https://github.com/cemozden))
+
 ## [2.0](https://github.com/brendaw/add-username-toppanel/releases/tag/v2.0) - 2022-11-22
 
 ### Added

--- a/README-pt-BR.md
+++ b/README-pt-BR.md
@@ -12,7 +12,7 @@ Simples assim.
 
 ## Compatibilidade
 
-Esta extensão é compatível desde a versão 3.12 até a 43 do GNOME Shell.
+Esta extensão é compatível desde a versão 3.12 até a 45 do GNOME Shell.
 
 ## Probemas Conhecidos
 
@@ -57,4 +57,4 @@ Veja no arquivo [AUTHORS](AUTHORS.md) a lista de nomes dos incríveis contribuid
 
 ## Licença
 
-[MIT](LICENSE) - William Brendaw e os contribuidores - 2016-2022
+[MIT](LICENSE) - William Brendaw e os contribuidores - 2016-2023

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ And is simple as that.
 
 ## Compatibility
 
-This extension is compatible with the GNOME Shell versions from 3.12 to 44.
+This extension is compatible with the GNOME Shell versions from 3.12 to 45.
 
 ## Common Issues
 
@@ -60,4 +60,4 @@ See on [AUTHORS](AUTHORS.md) file the amazing contributors' name of this project
 
 ## License
 
-[MIT](LICENSE) - William Brendaw and the contributors - 2016-2022
+[MIT](LICENSE) - William Brendaw and the contributors - 2016-2023

--- a/src/UsernameIndicator.js
+++ b/src/UsernameIndicator.js
@@ -1,0 +1,25 @@
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import { SystemIndicator } from 'resource:///org/gnome/shell/ui/quickSettings.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+export class UsernameIndicator extends SystemIndicator {
+
+    _init() {
+        super._init();
+
+        // Create the text label for a new indicator (child)
+        this._indicator = this._addIndicator();
+        const usernameLabel = new St.Label({
+            text:    GLib.get_real_name() + '  ',
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this.add_child(usernameLabel);
+
+        // This is the live instance of the Quick Settings menu
+        const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
+        QuickSettingsMenu.addExternalIndicator(this);
+    }
+
+};

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,42 +7,12 @@
   Hack it!
 */
 
-const Clutter = imports.gi.Clutter;
-const St = imports.gi.St;
-const Main = imports.ui.main;
-const GLib = imports.gi.GLib;
-const GObject = imports.gi.GObject;
-const QuickSettings = imports.ui.quickSettings;
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { UsernameIndicator } from './UsernameIndicator.js';
+import GObject from 'gi://GObject';
 
-// This is the live instance of the Quick Settings menu
-const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
-
-// Our QuickSettings.SystemIndicator subclass
-const UsernameIndicator = GObject.registerClass(
-class UsernameIndicator extends QuickSettings.SystemIndicator {
-
-    _init() {
-        // Chaining up to the super-class
-        super._init();
-
-        // Create the text label for a new indicator (child)
-        this._indicator = this._addIndicator();
-        const usernameLabel = new St.Label({
-            text:    GLib.get_real_name(),
-            y_align: Clutter.ActorAlign.CENTER,
-        });
-        this.add_child(usernameLabel);
-
-        // Add the indicator to the panel
-        QuickSettingsMenu._indicators.add_child(this)
-    }
-
-});
-
-class Extension {
-    constructor() {
-        this._indicator = null;
-    }
+export default class UsernameIndicatorExtension extends Extension {
+    _indicator;
 
     enable() {
         this._indicator = new UsernameIndicator();
@@ -54,7 +24,7 @@ class Extension {
     }
 }
 
-function init() {
-    return new Extension();
-}
-
+GObject.registerClass(
+    {GTypeName: 'UsernameIndicator'},
+    UsernameIndicator
+);

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,10 +6,9 @@
     "williambrendaw@icloud.com"
   ],
   "shell-version": [
-    "44",
-    "43"
+    "45"
   ],
   "url": "https://github.com/brendaw/add-username-toppanel",
   "uuid": "add-username-toppanel@brendaw.com",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
This PR converts the extension to ES6 with ESM (ECMAScript modules) instead of CommonJS.

This is since the GNOME project has required all extensions for GNOME Shell 45+ to be rewritten in this style, making them incompatible with GNOME Shell 44 and earlier.  Porting guide for extensions in version 45 is https://gjs.guide/extensions/upgrading/gnome-shell-45.html

We can still provide support for GNOME Shell 44 and earlier by keeping the extension version 11 active on the GNOME Extensions site, so that any users on those versions can continue to get the older version of the extension.  Users on 45+ will get the updated version of this extension.

One notable cosmetic change to be aware of is that the user name will now show up on the left of the series of indicator icons in the quick settings menu, i.e., just the the left of the brightness and wifi icons.  Before it showed up at the right end of everything, after the power indicator.  This is mainly since GNOME Shell 45 has a bit stronger of an opinion on "reasonable positions" of indicator icons, and it's a bit hacky to try to override this and try to reposition the indicators.  The upstream change was https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/93b89ce0c5c64a0770ea51120dc2326c1b3863ab with the merge request (for more context) at https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2894.  Anyhow, moving the username to the left of the system indicators is more in line with screenshots of how MacOS includes the username in the top bar, so it's not a crazy design idea.

Closes #15.