### PR TITLE
Fix username appearing on left end of Quick Settings

### DIFF
--- a/src/UsernameIndicator.js
+++ b/src/UsernameIndicator.js
@@ -17,9 +17,25 @@ export class UsernameIndicator extends SystemIndicator {
         });
         this.add_child(usernameLabel);
 
-        // This is the live instance of the Quick Settings menu
+        // GNOME's intended indicator layout is [privacy] [extensions] [system],
+        // so addExternalIndicator() places us in the middle slot. For a user
+        // name label we want it next to the system menu. Re-anchor to the end
+        // whenever a child is added — including our own insertion below, and
+        // any later siblings (system indicators still spinning up during
+        // auto-login boot, privacy icons turning on at runtime).
         const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
+        this._indicatorsBox = QuickSettingsMenu._indicators;
+        this._childAddedId = this._indicatorsBox.connect('child-added',
+            () => this._indicatorsBox.set_child_above_sibling(this, null));
         QuickSettingsMenu.addExternalIndicator(this);
+    }
+
+    destroy() {
+        if (this._childAddedId) {
+            this._indicatorsBox.disconnect(this._childAddedId);
+            this._childAddedId = 0;
+        }
+        super.destroy();
     }
 
 };


### PR DESCRIPTION
## Summary

Restores the username to the rightmost slot of the Quick Settings indicators bar (next to the system menu), where it used to sit before GNOME 45. Closes #21.

## What the bug is

Since GNOME 45 the extension uses the new public `addExternalIndicator()` API to register itself. Looking at the upstream implementation in [gnome-shell `js/ui/panel.js`](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panel.js):

```js
addExternalIndicator(indicator, colSpan = 1) {
    // Insert before first non-privacy indicator if it exists
    let sibling = this._brightness ?? null;
    this._indicators.insert_child_below(indicator, sibling);
    ...
}
```

The intent — documented in the introducing commit [`93b89ce0`](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/93b89ce0) by Florian Müllner — is a three-zone layout:

```
[ privacy ] [ external / extensions ] [ brightness, audio, …, system ]
```

The username therefore lands in the middle slot. On most desktops the privacy zone is empty (no camera/mic/location/screen-share in use), so visually the username appears at the **left** end of the system-menu button — exactly the regression reported in #21.

## The fix

There is no public API to control position within `_indicators`. We:

1. Still call `addExternalIndicator(this)` — so the menu-item half of the API contract (and any future improvements to it) keep working.
2. Then explicitly move our indicator to the end of the box with `set_child_above_sibling(this, null)`.

This is one line on top of the public API and restores the pre-GNOME-45 placement.

## Trade-offs / caveats

- `_indicators` is technically a private member of `QuickSettings` (underscore prefix). The GJS extension guide only accesses private members in narrowly-documented cases. We accept this cost because there is no alternative; the pre-45 code already accessed `_indicators` directly.
- This deliberately diverges from GNOME's "external indicators sit in the middle" design. The judgement call: a username label is meant to read like a label next to the user menu, not like another status icon mixed in with network/bluetooth.

## Test plan

- [ ] Install the packed extension on GNOME 45+ and confirm the username appears immediately to the left of the system menu button (rightmost in the indicators bar).
- [ ] With another extension that uses `addExternalIndicator()` installed, confirm the other extension's icon stays in the middle slot and the username remains rightmost.
- [ ] Trigger a privacy indicator (e.g. open the camera) and confirm it appears to the left of any extension icons; the username stays rightmost.
- [ ] Disable and re-enable the extension; confirm position is correct after re-enable.