### PR TITLE
fix: fall back to `username` if display name is unavailable

### DIFF
--- a/src/usernameIndicator.js
+++ b/src/usernameIndicator.js
@@ -10,8 +10,12 @@ export class UsernameIndicator extends SystemIndicator {
 
     // Create the text label for a new indicator (child)
     this._indicator = this._addIndicator();
+
+    let username = GLib.get_real_name();
+    username = username == "Unknown" ? GLib.get_user_name(): username;
+
     const usernameLabel = new St.Label({
-      text: GLib.get_real_name() + "    ",
+      text: username + "    ",
       y_align: Clutter.ActorAlign.CENTER,
     });
     this.add_child(usernameLabel);


### PR DESCRIPTION
## What does this PR do?
Fullfills suggestion in https://github.com/brendaw/add-username-toppanel/issues/33

Before this change, "Unknown" would be displayed on the left.

<!-- Brief description of the change -->

## Type of change

- [x] Bug fix
- [x] New feature / improvement
- [ ] Documentation
- [ ] Chore / maintenance

## Checklist

- [x] Tested locally with `./scripts/local.sh`
- [x] GNOME Shell version(s) tested: 50<!-- e.g. 48, 49 -->
- [ ] `metadata.json` shell-version updated (only if adding support for a new GNOME Shell version)

<!-- CHANGELOG and versioning are handled by the maintainer after merge -->
